### PR TITLE
Add exec permission to dispatch.fcgi on every deployment.

### DIFF
--- a/.flx
+++ b/.flx
@@ -1,8 +1,8 @@
 [setup]
-chmod 705 public_html/dispatch.fcgi
 
 [replace]
 public_html/dispatch.fcgi USER_NAME PROJECT_NAME
 
 [deploy]
+chmod 705 public_html/dispatch.fcgi
 bash fluxflex_deploy.sh

--- a/public_html/app.rb
+++ b/public_html/app.rb
@@ -1,5 +1,11 @@
 require 'rubygems'
 require 'sinatra'
+
+configure do
+  # disable rack-protection module that doesn't work with fluxflex
+  set :protection, :except => [:ip_spoofing]
+end
+
 get '/' do
     'Hello, Fluxflex world!'
 end


### PR DESCRIPTION
When it is deployed through git, the file is over-written with 644 permission,
and return 500.

There is detail: http://d.hatena.ne.jp/ToMmY/20110829 .
